### PR TITLE
Handle geolosys integration better

### DIFF
--- a/src/main/kotlin/com/cout970/magneticraft/block/core/BlockBase.kt
+++ b/src/main/kotlin/com/cout970/magneticraft/block/core/BlockBase.kt
@@ -203,14 +203,14 @@ open class BlockBase(material: Material) : Block(material), ICapabilityProvider 
         }
     }
 
-    override fun getStateForPlacement(world: World, pos: BlockPos, facing: EnumFacing,
+    override fun getStateForPlacement(world: World?, pos: BlockPos?, facing: EnumFacing,
                                       hitX: Float, hitY: Float, hitZ: Float, meta: Int,
-                                      placer: EntityLivingBase, hand: EnumHand): IBlockState {
+                                      placer: EntityLivingBase?, hand: EnumHand?): IBlockState {
 
         val state = super.getStateForPlacement(world, pos, facing, hitX, hitY, hitZ, meta, placer, hand)
         onBlockPlaced?.let {
             return it.invoke(
-                    OnBlockPlacedArgs(world, pos, facing, vec3Of(hitX, hitY, hitZ), meta, placer, hand, defaultState)
+                    OnBlockPlacedArgs(world!!, pos!!, facing, vec3Of(hitX, hitY, hitZ), meta, placer!!, hand!!, defaultState)
             )
         }
         return state


### PR DESCRIPTION
Hi there.  When trying to use Geolosys custom ore deposits, I ran into crashes with Magneticraft—because the ore deposits are calculated before a world has been loaded, it's not possible for `world`, `pos`, `placer` or `hand` to actually have defined values.  Most mods forward this to vanilla's implementation, which doesn't care about them being null, but Magneticraft does due to Kotlin.  This change makes that work better; it'll still cause a NullPointerException if there's an attempt to place a block, but since the above fields are null that doesn't happen.