### PR TITLE
Update buildcraft API name

### DIFF
--- a/src/main/kotlin/com/cout970/magneticraft/systems/integration/IntegrationHandler.kt
+++ b/src/main/kotlin/com/cout970/magneticraft/systems/integration/IntegrationHandler.kt
@@ -27,7 +27,7 @@ object IntegrationHandler {
         // also auto-loads classes with @ZenRegister
         craftTweaker = Loader.isModLoaded("crafttweaker")
         tconstruct = Loader.isModLoaded("tconstruct")
-        buildcraftApi = ModAPIManager.INSTANCE.hasAPI("BuildCraftAPI|fuels")
+        buildcraftApi = ModAPIManager.INSTANCE.hasAPI("buildcraftapi_fuels")
         industrialForegoing = Loader.isModLoaded("industrialforegoing")
 
         if(buildcraftApi){


### PR DESCRIPTION
Caused by https://github.com/BuildCraft/BuildCraftAPI/issues/44.